### PR TITLE
fixed snoozeFunctions to adjust the message displayed on Slack

### DIFF
--- a/internal/ticketinterfaces/plugins/slackTicket/webhookFunctions.go
+++ b/internal/ticketinterfaces/plugins/slackTicket/webhookFunctions.go
@@ -99,5 +99,5 @@ func snoozeFunction(s *SlackTicketService, event *slackevents.MessageEvent, spli
 		return s.sendSlackMessage(event.Channel, event.ThreadTimeStamp, "Something went wrong")
 	}
 	
-	return s.sendSlackMessage(event.Channel, event.ThreadTimeStamp, fmt.Sprintf("Snoozed Until: %d", ticket.SnoozeDate))
+	return s.sendSlackMessage(event.Channel, event.ThreadTimeStamp, fmt.Sprintf("Snoozed Until: %s", ticket.SnoozeDate))
 }


### PR DESCRIPTION
Small change in code to make the message go from this :
"Snoozed Until: %!d(string=2023-12-25T12:55:33Z)"

To this:
"Snoozed Until: 2023-12-25T13:09:44Z"
